### PR TITLE
Adding support to CLI parameterization.

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,6 +14,8 @@ import (
 	"github.com/v2fly/v2ray-core/v5/common"
 	"github.com/v2fly/v2ray-core/v5/common/buf"
 	"github.com/v2fly/v2ray-core/v5/common/cmdarg"
+
+	b64 "encoding/base64"
 )
 
 const (
@@ -29,6 +31,8 @@ const (
 	FormatProtobuf = "protobuf"
 	// FormatProtobufShort is the short of FormatProtobuf
 	FormatProtobufShort = "pb"
+	// No file. Used to get parameters via CLI.
+	NoFile = "nofile"
 )
 
 // ConfigFormat is a configurable format of V2Ray config file.
@@ -128,6 +132,25 @@ func LoadConfig(formatName string, input interface{}) (*Config, error) {
 		return nil, newError("config loader not found: ", formatName).AtWarning()
 	}
 	return f.Loader(input)
+}
+
+// LoadConfigFromBase64 loads the configuration from a base 64 string.
+// base64config accepts:
+// * JSON-formatted configuration encoded in base 64 string format
+func LoadConfigFromBase64(base64config string) (*Config, error) {
+	log.Println("Using config from CLI.")
+
+	if len(base64config) > 0 {
+		configBytes, err := b64.StdEncoding.DecodeString(base64config)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return loadSingleConfigByTryingAllLoaders(configBytes)
+	}
+
+	return nil, newError("Unable to load configuration from CLI. Was that a valid configuration?").AtWarning()
 }
 
 // loadSingleConfigAutoFormat loads a single config with from given source.

--- a/core.go
+++ b/core.go
@@ -21,7 +21,7 @@ var (
 	version  = "5.7.0"
 	build    = "Custom"
 	codename = "V2Fly, a community-driven edition of V2Ray."
-	intro    = "A unified platform for anti-censorship."
+	intro    = "A unified platform for anti-censorship. Modded by TunnelBear -- Rawr."
 )
 
 // Version returns V2Ray's version as a string, in the form of "x.y.z" where x, y and z are numbers.

--- a/main/main.go
+++ b/main/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	base.RootCommand.Long = "A unified platform for anti-censorship."
+	base.RootCommand.Long = "A unified platform for anti-censorship. Modded by TunnelBear -- Rawr."
 	base.RegisterCommand(commands.CmdRun)
 	base.RegisterCommand(commands.CmdVersion)
 	base.RegisterCommand(commands.CmdTest)


### PR DESCRIPTION
This update will allow V2Ray to receive base64-encoded JSON (the settings to run V2Ray with) via CLI.